### PR TITLE
fix path for the registryTags API route

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -179,7 +179,7 @@ var registryPaths = []registryPath{
 	{Name: "registryCatalog", Regexp: regexp.MustCompile(`^/v2/_catalog$`),
 		Get: registry.catalog},
 
-	{Name: "registryTags", Regexp: regexp.MustCompile(`^/v2/([a-z0-9]+(?:[\._-][a-z0-9]+)*)/list/tags$`),
+	{Name: "registryTags", Regexp: regexp.MustCompile(`^/v2/([a-z0-9]+(?:[\._-][a-z0-9]+)*)/tags/list$`),
 		Get: registry.tags},
 
 	// The element after manifests can be a tag, or a digest.

--- a/registry_test.go
+++ b/registry_test.go
@@ -313,7 +313,7 @@ func TestRegistry(t *testing.T) {
 
 	checkRequest(reg, true, "GET", "/v2/", nil, nil, http.StatusOK, nil, "")
 	checkRequest(reg, true, "GET", "/v2/_catalog", nil, nil, http.StatusOK, nil, "")
-	checkRequest(reg, true, "GET", "/v2/testrepo/list/tags", nil, nil, http.StatusOK, nil, "")
+	checkRequest(reg, true, "GET", "/v2/testrepo/tags/list", nil, nil, http.StatusOK, nil, "")
 	checkRequest(reg, true, "GET", "/v2/testrepo/manifests/image", nil, nil, http.StatusOK, nil, "")
 	checkRequest(reg, true, "GET", "/v2/testrepo/manifests/imagedup", nil, nil, http.StatusOK, nil, "")
 	checkRequest(reg, true, "GET", "/v2/testrepo/manifests/list", nil, nil, http.StatusOK, nil, "")


### PR DESCRIPTION
Wrong: `/v2/<repo>/list/tags`
Right: `/v2/<repo>/tags/list`

Fixes #3.